### PR TITLE
Add support for Windows x64

### DIFF
--- a/globaldefines.h
+++ b/globaldefines.h
@@ -29,7 +29,13 @@
 #define PLATFORM    "linux2"
 #define ENGINE_FILENAME QString("./TTREngine")
 
-//for windows support (should now work)
+//for windows support (64bit)
+#elif defined(Q_OS_WIN64)
+#define DEFAULT_PATH QString(QDir::currentPath()) + QString("/Game-Files")
+#define ENGINE_FILENAME QString("TTREngine64.exe")
+#define PLATFORM    "win64"
+
+//for windows support (32bit)
 #elif defined(Q_OS_WIN)
 #define DEFAULT_PATH QString(QDir::currentPath()) + QString("/Game-Files")
 #define ENGINE_FILENAME QString("TTREngine.exe")


### PR DESCRIPTION
Toontown Rewritten recently released a 64-bit executable on Windows (patch ttr-live-v2.10.3), and there is currently a lot of crash issues with the 32-bit executable. This should enable users to download/run TTR in 64 bit.